### PR TITLE
httptools 0.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,23 +7,21 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
-  number: 1
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
-  skip: true  # [py2k]
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - {{ compiler('c') }}
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
 
@@ -39,7 +37,12 @@ about:
   home: https://github.com/MagicStack/httptools
   summary: Fast HTTP parser
   license: MIT
+  license_family: MIT
   license_file: LICENSE
+  description: |
+    httptools is a Python binding for the nodejs HTTP parser.
+  doc_url: https://github.com/MagicStack/httptools
+  dev_url: https://github.com/MagicStack/httptools
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Changelog: https://github.com/MagicStack/httptools/releases
License: https://github.com/MagicStack/httptools/blob/v0.5.0/LICENSE
Requirements:
- https://github.com/MagicStack/httptools/blob/v0.5.0/setup.py

Actions:
1. Remove obsolete source/fn
2. Reset build number
3. Add setuptools and wheel
4. Add license_family
5. Add description
6. Add dev and doc urls